### PR TITLE
Fix the bug about adding points via Xsolla webhook and also edit a mi…

### DIFF
--- a/app/Services/XsollaWebhookService.php
+++ b/app/Services/XsollaWebhookService.php
@@ -113,7 +113,7 @@ class XsollaWebhookService
                     UserItem::scopePurchaseUserItem($user->id, $purchaseItem->id, 'xsolla');
                 }
             } else {
-                $user->points += (round($purchaseData['virtual_currency']['amount']) * $purchaseData['virtual_currency']['quantity']);
+                $user->points += $purchaseData['virtual_currency']['quantity'];
             }
 
             $user->save();
@@ -122,7 +122,7 @@ class XsollaWebhookService
             return response([
                 'success' => [
                     'code' => 'SUCCESS_PAYMENT',
-                    'message' => 'The payment has been successfully completed successfully.',
+                    'message' => 'The payment has been completed successfully.',
                 ],
             ], HTTP_OK);
         } catch (\Exception $e) {


### PR DESCRIPTION
…nor typo

`$purchaseData['virtual_currency']['amount']`는 가상 화폐(포인트)를 구매한 현금의 액수를 의미해요. (ex: 500P 패키지 구입하는데 5500원을 썼다면 purchase.virtual_currency.amount == 5500) 따라서 User.points를 수정하는 데 있어서는 의미가 없는 값이라 계산에서 제외했습니다.

사소한 오타도 수정했어요